### PR TITLE
Check Context URI For Song

### DIFF
--- a/src/spotify.ts
+++ b/src/spotify.ts
@@ -52,20 +52,29 @@ export async function play(
   { context_uri, deviceId, offset = 0, uris }: IPlayOptions,
   token: string,
 ) {
-  let body;
+
+  let body, isArtist, isAlbum, isPlaylist, position;
 
   if (context_uri) {
-    const isArtist = context_uri.indexOf('artist') >= 0;
-    let position;
+      var splitContextURI = context_uri.split(":")
+      isArtist = splitContextURI[1] === "artist";
+      isAlbum = splitContextURI[1] === "album";
+      isPlaylist = splitContextURI[1] === "playlist";
+      position = void 0;
 
-    if (!isArtist) {
-      position = { position: offset };
-    }
-
-    body = JSON.stringify({ context_uri, offset: position });
-  } else if (Array.isArray(uris) && uris.length) {
-    body = JSON.stringify({ uris, offset: { position: offset } });
-  }
+      if (isArtist) {
+          position = { position: offset };
+          body = JSON.stringify({ context_uri: context_uri , offset: position })
+      } else if(isAlbum){
+          position = { position: offset };
+          body = JSON.stringify({ context_uri: context_uri , offset: position })
+      } else if(isPlaylist){
+          position = { position: offset };
+          body = JSON.stringify({ context_uri: context_uri , offset: position })
+      } else{
+          body = JSON.stringify({ uris: uris, offset: { position: offset } });
+      } 
+   }
 
   return fetch(`https://api.spotify.com/v1/me/player/play?device_id=${deviceId}`, {
     body,


### PR DESCRIPTION

wanted to show that context_uri needs to check if its album, artist or playlist otherwise send it under the uris paramter to play it as a song 
https://developer.spotify.com/documentation/web-api/reference/player/start-a-users-playback/
would be better to catch this before and then decide if it has context uri send it else send uris for a song
couldn't find where to do that in the repo
don't need to worry about an array of uris really because you can just add it to the queue
https://developer.spotify.com/documentation/web-api/reference/player/add-to-queue/