### PR TITLE
Add episode as a valid Spotify URI

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -115,7 +115,7 @@ export function round(number: number, digits = 2) {
 }
 
 export function validateURI(input: string): boolean {
-  const validTypes = ['album', 'artist', 'playlist', 'show', 'track'];
+  const validTypes = ['album', 'artist', 'playlist', 'show', 'episode', 'track'];
 
   /* istanbul ignore else */
   if (input && input.indexOf(':') > -1) {

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -99,7 +99,7 @@ describe('validateURI', () => {
   it.each([
     ['spotify:album:51QBkcL7S3KYdXSSA0zM9R', true],
     ['spotify:artist:7A0awCXkE1FtSU8B0qwOJQ', true],
-    ['spotify:episode:6r8OOleI5xP7qCEipHvdyK', false],
+    ['spotify:episode:6r8OOleI5xP7qCEipHvdyK', true],
     ['spotify:playlist:5kHMGRfZHORA4UrCbhYyad', true],
     ['spotify:show:5huEzXsf133dhbh57Np2tg', true],
     ['spotify:track:0gkVD2tr14wCfJhqhdE94L', true],


### PR DESCRIPTION
Per Spotify's API: https://developer.spotify.com/documentation/web-api/reference/#/operations/get-an-episode

The uri for playing a show's episode is in the following format: `spotify:episode:xxxxxxxx`

This PR adds `episode` as a valid Spotify URI