### PR TITLE
Fix callback progressMs stale value

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -318,11 +318,12 @@ class SpotifyWebPlayer extends PureComponent<Props, State> {
 
     try {
       const percentage = position / 100;
-      progress = Math.round(track.durationMs * percentage);
 
       let stateChanges = {};
 
       if (this.isExternalPlayer) {
+        progress = Math.round(track.durationMs * percentage);
+
         await seek(this.token, progress);
 
         stateChanges = {
@@ -333,6 +334,7 @@ class SpotifyWebPlayer extends PureComponent<Props, State> {
         const state = await this.player.getCurrentState();
 
         if (state) {
+          progress = Math.round(state.track_window.current_track.duration_ms * percentage);
           await this.player.seek(progress);
 
           stateChanges = {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -318,34 +318,38 @@ class SpotifyWebPlayer extends PureComponent<Props, State> {
 
     try {
       const percentage = position / 100;
+      progress = Math.round(track.durationMs * percentage);
+
+      let stateChanges = {};
 
       if (this.isExternalPlayer) {
-        progress = Math.round(track.durationMs * percentage);
         await seek(this.token, progress);
 
-        this.updateState({
+        stateChanges = {
           position,
           progressMs: progress,
-        });
+        };
       } else if (this.player) {
         const state = await this.player.getCurrentState();
 
         if (state) {
-          progress = Math.round(state.track_window.current_track.duration_ms * percentage);
           await this.player.seek(progress);
 
-          this.updateState({
+          stateChanges = {
             position,
             progressMs: progress,
-          });
+          };
         } else {
-          this.updateState({ position: 0 });
+          stateChanges = { position: 0 };
         }
       }
+
+      this.updateState(stateChanges);
 
       if (callback) {
         callback({
           ...this.state,
+          ...stateChanges,
           type: TYPE.PROGRESS,
         });
       }


### PR DESCRIPTION
The callback state was reporting the old state, and not the new modified one, every time a `TYPE.PROGRESS` event occurred.