### PR TITLE
Fix exenv module import

### DIFF
--- a/src/modules/helpers.ts
+++ b/src/modules/helpers.ts
@@ -1,9 +1,9 @@
 /* eslint-disable camelcase */
-import { canUseDOM as canUseDOMBool } from 'exenv';
+import * as exenv from 'exenv';
 
 import { SpotifyTrack } from '~/types';
 
-export const canUseDOM = () => canUseDOMBool;
+export const canUseDOM = () => exenv.canUseDOM;
 
 export function convertTrack(track: Spotify.Track): SpotifyTrack {
   const { album, artists, duration_ms, id, name, uri } = track;


### PR DESCRIPTION
`exenv` is defined as a CommonJS module and being imported as a ES6 module.
It works not in all environments (see issue #144 and discussion #143 for instance, also [example issue](https://stackoverflow.com/questions/70605320/named-export-types-not-found-the-requested-module-mongoose-is-a-commonjs-mo))

Changing the import syntax solves the problem: https://stackoverflow.com/questions/29596714/new-es6-syntax-for-importing-commonjs-amd-modules-i-e-import-foo-require