### PR TITLE
Handle an Unhandled Promise Rejection in helpers.ts TypeScript file

### DIFF
--- a/src/modules/helpers.ts
+++ b/src/modules/helpers.ts
@@ -64,6 +64,7 @@ export function loadSpotifyPlayer(): Promise<any> {
       reject();
     }
   }).catch((error: any) => { console.log(error) });
+}
 
 export function millisecondsToTime(input: number) {
   const seconds = Math.floor((input / 1000) % 60);

--- a/src/modules/helpers.ts
+++ b/src/modules/helpers.ts
@@ -61,10 +61,9 @@ export function loadSpotifyPlayer(): Promise<any> {
 
       document.head.appendChild(script);
     } else {
-      resolve();
+      reject();
     }
-  });
-}
+  }).catch((error: any) => { console.log(error) });
 
 export function millisecondsToTime(input: number) {
   const seconds = Math.floor((input / 1000) % 60);


### PR DESCRIPTION
I am building a better Spotify with React and this library. I have been getting `Unhandled Promise Rejection: Error: loadScript: undefined` index.tsx:171. Line 171 includes call to function loadSpotifyPlayer() from helpers.ts. The function loadSpotifyPlayer() returns a Promise that does not handle rejection well. This bug fix should handle the rejections better.