### PR TITLE
Fixes types not being exported

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-spotify-web-playback",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "A React Spotify Web Player",
   "author": "Gil Barbara <gilbarbara@gmail.com>",
   "repository": {
@@ -15,7 +15,8 @@
   "module": "./dist/index.mjs",
   "exports": {
     "import": "./dist/index.mjs",
-    "require": "./dist/index.js"
+    "require": "./dist/index.js",
+    "types": "./dist/index.d.ts"
   },
   "files": [
     "dist",


### PR DESCRIPTION
On newer versions of TypeScript, it obeys the "exports" field if it's present. This creates an issue when types aren't exported: 
<img width="1000" alt="Screenshot 2023-09-18 at 11 29 13" src="https://github.com/gilbarbara/react-spotify-web-playback/assets/34555510/17b5980c-236a-4eef-866a-c91d429c059e">

Refs https://github.com/microsoft/TypeScript/issues/33079

This pull request fixes the issue.
After:
<img width="586" alt="Screenshot 2023-09-18 at 11 35 20" src="https://github.com/gilbarbara/react-spotify-web-playback/assets/34555510/5a7592eb-744f-4c98-9c5d-e0476330e088">

I've verified that this fix works on a starter Next.js project locally as well.

I changed the version number by a semver-minor version because hypothetically, if anyone is suppressing this issue in their projects (e.g. with `// @ts-ignore` or `@ts-expect-error`), they will now be given an error saying a redundant `ts-*` comment is being used.