### PR TITLE
Add support for transparent bg

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,9 @@ interface SpotifyPlayOptions {
 
 ## Styling
 
-You can customize the UI with a `styles` prop. Check all the available options [here](src/types/common.ts#L159).
+You can customize the UI with a `styles` prop.  
+If you want a transparent player, you can use `bgColor: 'transparent'`.  
+Check all the available options [here](src/types/common.ts#L188).
 
 ```tsx
 <SpotifyWebPlayer

--- a/src/components/Info.tsx
+++ b/src/components/Info.tsx
@@ -2,6 +2,7 @@ import { memo, ReactNode, useEffect, useRef, useState } from 'react';
 import { fade } from 'colorizr';
 
 import { getSpotifyLink, getSpotifyLinkTitle } from '~/modules/getters';
+import { getMaskImageColor } from '~/modules/helpers';
 import { usePrevious } from '~/modules/hooks';
 import { checkTracksStatus, removeTracks, saveTracks } from '~/modules/spotify';
 import { CssLikeObject, px, styled } from '~/modules/styled';
@@ -182,13 +183,15 @@ const Content = styled('div')(
     },
   },
   ({ style }: StyledProps) => {
+    const maskImageColor = getMaskImageColor(style.trackNameColor, style.bgColor);
+
     return {
       '[data-type="title-artist-wrapper"]': {
         color: style.trackNameColor,
         maxWidth: `calc(100% - ${px(style.showSaveIcon ? iconSize : 0)})`,
 
         div: {
-          '-webkit-mask-image': `linear-gradient(90deg,transparent 0, ${style.trackNameColor} 6px, ${style.trackNameColor} calc(100% - 12px),transparent)`,
+          '-webkit-mask-image': `linear-gradient(90deg,transparent 0, ${maskImageColor} 6px, ${maskImageColor} calc(100% - 12px),transparent)`,
         },
       },
       p: {

--- a/src/components/Info.tsx
+++ b/src/components/Info.tsx
@@ -188,7 +188,7 @@ const Content = styled('div')(
         maxWidth: `calc(100% - ${px(style.showSaveIcon ? iconSize : 0)})`,
 
         div: {
-          '-webkit-mask-image': `linear-gradient(90deg,transparent 0, ${style.bgColor} 6px, ${style.bgColor} calc(100% - 12px),transparent)`,
+          '-webkit-mask-image': `linear-gradient(90deg,transparent 0, ${style.trackNameColor} 6px, ${style.trackNameColor} calc(100% - 12px),transparent)`,
         },
       },
       p: {

--- a/src/components/Info.tsx
+++ b/src/components/Info.tsx
@@ -1,8 +1,7 @@
 import { memo, ReactNode, useEffect, useRef, useState } from 'react';
 import { fade } from 'colorizr';
 
-import { getSpotifyLink, getSpotifyLinkTitle } from '~/modules/getters';
-import { getMaskImageColor } from '~/modules/helpers';
+import { getBgColor, getSpotifyLink, getSpotifyLinkTitle } from '~/modules/getters';
 import { usePrevious } from '~/modules/hooks';
 import { checkTracksStatus, removeTracks, saveTracks } from '~/modules/spotify';
 import { CssLikeObject, px, styled } from '~/modules/styled';
@@ -183,7 +182,7 @@ const Content = styled('div')(
     },
   },
   ({ style }: StyledProps) => {
-    const maskImageColor = getMaskImageColor(style.trackNameColor, style.bgColor);
+    const maskImageColor = getBgColor(style.bgColor, style.trackNameColor);
 
     return {
       '[data-type="title-artist-wrapper"]': {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,8 @@ export const STATUS = {
   UNSUPPORTED: 'UNSUPPORTED',
 } as const;
 
+export const TRANSPARENT_COLOR = 'rgba(0, 0, 0, 0)';
+
 export const TYPE = {
   DEVICE: 'device_update',
   FAVORITE: 'favorite_update',

--- a/src/modules/getters.ts
+++ b/src/modules/getters.ts
@@ -1,3 +1,5 @@
+import { adaptBgColor } from '~/modules/helpers';
+
 import { Locale, StylesOptions, StylesProps } from '~/types';
 
 export function getLocale(locale?: Partial<Locale>): Locale {
@@ -18,7 +20,7 @@ export function getLocale(locale?: Partial<Locale>): Locale {
 }
 
 export function getMergedStyles(styles?: StylesProps): StylesOptions {
-  return {
+  const mergedStyles = {
     activeColor: '#1cb954',
     altColor: '#ccc',
     bgColor: '#fff',
@@ -37,6 +39,10 @@ export function getMergedStyles(styles?: StylesProps): StylesOptions {
     trackNameColor: '#333',
     ...styles,
   };
+
+  mergedStyles.bgColor = adaptBgColor(mergedStyles.bgColor);
+
+  return mergedStyles;
 }
 
 export function getSpotifyLink(uri: string): string {

--- a/src/modules/getters.ts
+++ b/src/modules/getters.ts
@@ -1,6 +1,13 @@
-import { adaptBgColor } from '~/modules/helpers';
-
+import { TRANSPARENT_COLOR } from '~/constants';
 import { Locale, StylesOptions, StylesProps } from '~/types';
+
+export function getBgColor(bgColor: string, fallbackColor?: string): string {
+  if (fallbackColor) {
+    return bgColor === TRANSPARENT_COLOR ? fallbackColor : bgColor;
+  }
+
+  return bgColor === 'transparent' ? TRANSPARENT_COLOR : bgColor;
+}
 
 export function getLocale(locale?: Partial<Locale>): Locale {
   return {
@@ -40,7 +47,7 @@ export function getMergedStyles(styles?: StylesProps): StylesOptions {
     ...styles,
   };
 
-  mergedStyles.bgColor = adaptBgColor(mergedStyles.bgColor);
+  mergedStyles.bgColor = getBgColor(mergedStyles.bgColor);
 
   return mergedStyles;
 }

--- a/src/modules/helpers.ts
+++ b/src/modules/helpers.ts
@@ -122,13 +122,3 @@ export function validateURI(input: string): boolean {
 
   return false;
 }
-
-const transparentBgColor = 'rgba(0, 0, 0, 0)';
-
-export function adaptBgColor(bgColor: string): string {
-  return bgColor === 'transparent' ? transparentBgColor : bgColor;
-}
-
-export function getMaskImageColor(trackNameColor: string, bgColor: string): string {
-  return bgColor === transparentBgColor ? trackNameColor : bgColor;
-}

--- a/src/modules/helpers.ts
+++ b/src/modules/helpers.ts
@@ -122,3 +122,13 @@ export function validateURI(input: string): boolean {
 
   return false;
 }
+
+const transparentBgColor = 'rgba(0, 0, 0, 0)';
+
+export function adaptBgColor(bgColor: string): string {
+  return bgColor === 'transparent' ? transparentBgColor : bgColor;
+}
+
+export function getMaskImageColor(trackNameColor: string, bgColor: string): string {
+  return bgColor === transparentBgColor ? trackNameColor : bgColor;
+}

--- a/test/modules/__snapshots__/getters.spec.ts.snap
+++ b/test/modules/__snapshots__/getters.spec.ts.snap
@@ -20,7 +20,7 @@ exports[`getMergedStyles should return a merged styles 1`] = `
 {
   "activeColor": "#1cb954",
   "altColor": "#ccc",
-  "bgColor": "#fff",
+  "bgColor": "rgba(0, 0, 0, 0)",
   "color": "#333",
   "errorColor": "#ff0026",
   "height": 100,

--- a/test/modules/getters.spec.ts
+++ b/test/modules/getters.spec.ts
@@ -1,10 +1,23 @@
 import {
+  getBgColor,
   getLocale,
   getMergedStyles,
   getSpotifyLink,
   getSpotifyLinkTitle,
   getSpotifyURIType,
 } from '~/modules/getters';
+
+import { TRANSPARENT_COLOR } from '~/constants';
+
+describe('getBgColor', () => {
+  it('should return the background color', () => {
+    expect(getBgColor('#f04')).toBe('#f04');
+  });
+
+  it('should return the transparent color', () => {
+    expect(getBgColor('transparent')).toBe(TRANSPARENT_COLOR);
+  });
+});
 
 describe('getLocale', () => {
   it('should return a merged locale', () => {
@@ -14,7 +27,7 @@ describe('getLocale', () => {
 
 describe('getMergedStyles', () => {
   it('should return a merged styles', () => {
-    expect(getMergedStyles({ height: 100 })).toMatchSnapshot();
+    expect(getMergedStyles({ bgColor: 'transparent', height: 100 })).toMatchSnapshot();
   });
 });
 


### PR DESCRIPTION
By setting the style `bgColor='transparent'` internally a value of `rgba(0, 0, 0, 0)` is set and in that case the maskImageColor for fading the song title is set to the `trackNameColor`.

Not sure how/where to document it?

Discussion see: #164 